### PR TITLE
Fix bundle dependencies on SLF4J

### DIFF
--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -63,9 +63,11 @@
 							org.eclipse.californium.elements*
 						</Export-Package>
 						<Import-Package>
+							org.slf4j.bridge;resolution:=optional,
 							*
 						</Import-Package>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+						<_noclassforname>true</_noclassforname>
 					</instructions>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
For Californium elements the org.slf4j.bridge should be an optional dependency as other JUL bridges like log4j-jul might already be present.